### PR TITLE
Stop wg interface before trying to reconfdigure the PIA connection

### DIFF
--- a/pia_wg.sh
+++ b/pia_wg.sh
@@ -244,9 +244,10 @@ EOI
 }
 
 start_wgpia() {
+  echo "Stopping PIA ($(uci get network.$PIAWG_PEER.description))"
+  ifdown $PIAWG_IF >/dev/null 2>&1
   set_netconf
   echo "Starting PIA ($(uci get network.$PIAWG_PEER.description))"
-  ifdown $PIAWG_IF >/dev/null 2>&1
   ifup $PIAWG_IF
   sleep 1
   check_wg


### PR DESCRIPTION
Stop the wg interface via `ifdown` before trying to reconfigure the wg setup.

Fixes https://github.com/bolemo/pia_wg/issues/11