### PR TITLE
Fix inet is expected

### DIFF
--- a/pia_wg.sh
+++ b/pia_wg.sh
@@ -386,7 +386,7 @@ check_wg() {
     PIAWG_EP="$(wg show "$PIAWG_IF" endpoints | awk -F'[[:space:]:]' '{print $2; exit;}')"
     PIAWG_MK="$(wg show "$PIAWG_IF" fwmark)"
     [ "$PIAWG_MK" = "off" ] && PIAWG_MK='' || PIAWG_MK="mark $PIAWG_MK"
-    WAN_IF="$(ip route get "$PIAWG_EP" "$PIAWG_MK" | awk '{for(i=0;i<NF;i++){if($i=="dev"){print $++i; exit;}}}')"
+    WAN_IF="$(ip route get "$PIAWG_EP" ${PIAWG_MK:+"$PIAWG_MK"} | awk '{for(i=0;i<NF;i++){if($i=="dev"){print $++i; exit;}}}')"
     echo "WireGuard PIA interface: UP"
   else
     echo "WireGuard PIA interface: DOWN!" >&3


### PR DESCRIPTION
Fix the error where PIAWG_MK is empty:

* If PIAWG_MK is non-empty: expand to "$PIAWG_MK" (the quoted value)
* If PIAWG_MK is empty: expand to nothing (no argument at all)

Fixes https://github.com/bolemo/pia_wg/issues/20

