### PR TITLE
Print watchdog installed status once

### DIFF
--- a/pia_wg.sh
+++ b/pia_wg.sh
@@ -582,10 +582,14 @@ case "$1" in
 'status')
   check_wg
   R=$?
-  watchdog_installed && {
+  if watchdog_installed; then
     echo "Watchdog (cron) installed: YES"
-    WLR="$(watchdog_lastrun)" && echo "Watchdog last check: $WLR"
-  } || echo "Watchdog (cron) installed: NO"
+    if WLR="$(watchdog_lastrun)"; then
+      echo "Watchdog last check: $WLR"
+    fi
+  else
+    echo "Watchdog (cron) installed: NO"
+  fi
   exit $R
   ;;
 'log') case "$2" in


### PR DESCRIPTION
Handle the case where `/var/log/pia_wg_watchdog.log` does not exist and print `Watchdog (cron) installed: ` only once in status.

Fixes https://github.com/bolemo/pia_wg/issues/22

